### PR TITLE
feat: Add adservice.google.se

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -11,7 +11,8 @@
       "s0.2mdn.net",
       "stats.g.doubleclick.net",
       "survey.g.doubleclick.net",
-      "www.googleadservices.com"
+      "www.googleadservices.com",
+      "adservice.google.se"
     ]
   },
   {


### PR DESCRIPTION
In Sweden that domain is used also for ads, I wonder if we need one
per country? And this will pickup everything for *.google.se also as ads @patrickhulce ?