### PR TITLE
Fix InAuth in entities

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -2902,7 +2902,7 @@
   {
     "name": "InAuth",
     "categories": ["utility"],
-    "homepage": "https://www.inauth.com/"
+    "homepage": "https://www.inauth.com/",
     "domains": ["*.cdn-net.com"],
     "examples": ["uk.cdn-net.com"]
   },

--- a/data/entities.json5
+++ b/data/entities.json5
@@ -2708,9 +2708,10 @@
     "domains": ["cdnplanet.com"]
   },
   {
-    "name": "CDN.net",
+    "name": "InAuth",
     "categories": ["utility"],
-    "domains": ["uk.cdn-net.com"]
+    "homepage": "https://www.inauth.com/"
+    "domains": ["cdn-net.com"]
   },
   {
     "name": "CJ Affiliate",


### PR DESCRIPTION
Fix [InAuth](https://www.inauth.com/) to entities. 

Most sites use their product called [InAuth Inbrowser](https://www.inauth.com/products/inauth-security-platform/inbrowser/). It's a browser fingerprinting solution so I added it as a `"utility"`.