### PR TITLE
misc: add dynatrace cdn origin to domains array in entities

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -3997,7 +3997,7 @@
   {
     "name": "Dynatrace",
     "categories": ["analytics"],
-    "domains": ["*.ruxit.com"]
+    "domains": ["*.ruxit.com", "js-cdn.dynatrace.com"]
   },
   {
     "name": "ECT News Network",


### PR DESCRIPTION
I've been seeing js-cdn.dynatrace.com pop up lately. This PR adds this origin to the domains list within entities.

![image](https://user-images.githubusercontent.com/643503/63104408-cd4b1d00-bf33-11e9-8dc6-79fb6512a643.png)
