### PR TITLE
Add bizibly to Bizible

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -2654,7 +2654,7 @@
   {
     "name": "Bizible",
     "categories": ["ad"],
-    "domains": ["*.bizible.com"]
+    "domains": ["*.bizible.com", "*.bizibly.com"]
   },
   {
     "name": "Bizrate",


### PR DESCRIPTION
At the very least, cdn.bizibly.com serves content initiated by Bizible.

