### PR TITLE
fix Sumo entity domain list (#66)

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -640,7 +640,7 @@
     "name": "Sumo",
     "homepage": "https://sumo.com/",
     "categories": ["marketing"],
-    "domains": ["*.sumo.com", "*.sumome.com", "*.b-cdn.net"],
+    "domains": ["*.sumo.com", "*.sumome.com", "sumo.b-cdn.net"],
     "examples": ["sumo.b-cdn.net", "load.sumo.com", "load.sumome.com"]
   },
   {


### PR DESCRIPTION
Fixing issue #66 where the domain *.b-cdn.net was incorrectly detected as Sumo service.

closes #66