### PR TITLE
add Statuspage.io to entities

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -11443,5 +11443,16 @@
         "app.launchdarkly.com",
         "events.launchdarkly.com"
     ]
+  },
+  {
+    "name": "Statuspage",
+    "company": "Atlassian",
+    "homepage": "https://www.statuspage.io",
+    "categories": ["utility"],
+    "domains": ["*.statuspage.io"],
+    "examples": [
+        "app.launchdarkly.com",
+        "events.launchdarkly.com"
+    ]
   }
 ]

--- a/data/entities.json5
+++ b/data/entities.json5
@@ -11451,8 +11451,7 @@
     "categories": ["utility"],
     "domains": ["*.statuspage.io"],
     "examples": [
-        "app.launchdarkly.com",
-        "events.launchdarkly.com"
+        "1k6wzpspjf99.statuspage.io"
     ]
   }
 ]


### PR DESCRIPTION
add Atlassian's Statuspage as utility.
It's used to display a service status on websites.