### PR TITLE
update entity for Baidu Analytics

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -287,8 +287,8 @@
     "name": "Baidu Analytics",
     "homepage": "https://tongji.baidu.com/web/welcome/login",
     "categories": ["analytics"],
-    "domains": ["*.baidu.com"],
-    "examples": ["hm.baidu.com"]
+    "domains": ["hm.baidu.com", "hmcdn.baidu.com"],
+    "examples": ["hm.baidu.com", "hmcdn.baidu.com"]
   },
   {
     "name": "Adobe Tag Manager",


### PR DESCRIPTION
The current setting for `Baidu Analytics` includes all the resources from *.baidu.com
But actually `Baidu Analytics` only has two domains (hm.baidu.com and hmcdn.baidu.com)