### PR TITLE
feat: add getProduct to API

### DIFF
--- a/data/entities.json5
+++ b/data/entities.json5
@@ -211,7 +211,7 @@
         facades: [
           {
             name: 'Lite YouTube',
-            repo: 'https://github.com/paulirish/lite-youtube-embed#other-lite-embeds',
+            repo: 'https://github.com/paulirish/lite-youtube-embed',
           },
         ],
       },

--- a/data/entities.json5
+++ b/data/entities.json5
@@ -202,6 +202,20 @@
       'img.youtube.com',
       'fcmatch.youtube.com',
     ],
+    products: [
+      {
+        name: 'YouTube Embedded Player',
+        urlPatterns: [
+          '.*\\.youtube\\.com/embed/.*',
+        ],
+        facades: [
+          {
+            name: 'Lite YouTube',
+            repo: 'https://github.com/paulirish/lite-youtube-embed#other-lite-embeds',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'Twitter',

--- a/lib/create-entity-finder-api.js
+++ b/lib/create-entity-finder-api.js
@@ -28,6 +28,21 @@ function getEntityInDataset(entityByDomain, entityByRootDomain, originOrURL) {
   return undefined
 }
 
+function getProductInDataset(entityByDomain, entityByRootDomain, originOrURL) {
+  const entity = getEntityInDataset(entityByDomain, entityByRootDomain, originOrURL);
+  const products = entity && entity.products;
+  if (!products) return undefined;
+  for (const product of products) {
+    for (const pattern of product.urlPatterns) {
+      const regex = new RegExp(pattern);
+      if (regex.test(originOrURL)) {
+        return product;
+      }
+    }
+  }
+  return undefined;
+}
+
 function createAPIFromDataset(entities_) {
   const entities = JSON.parse(JSON.stringify(entities_))
   const entityByDomain = new Map()
@@ -59,7 +74,8 @@ function createAPIFromDataset(entities_) {
   }
 
   const getEntity = getEntityInDataset.bind(null, entityByDomain, entityByRootDomain)
-  return {getEntity, getRootDomain, entities}
+  const getProduct = getProductInDataset.bind(null, entityByDomain, entityByRootDomain)
+  return {getEntity, getProduct, getRootDomain, entities}
 }
 
 module.exports = {createAPIFromDataset}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,9 +1,21 @@
+export interface IFacade {
+  name: string
+  repo: string
+}
+
+export interface IProduct {
+  name: string
+  urlPatterns: string[]
+  facades: IFacade[]
+}
+
 export interface IEntity {
   name: string
   company: string
   homepage?: string
   categories: string[]
   domains: string[]
+  products: IProduct[]
   averageExecutionTime: number
   totalExecutionTime: number
   totalOccurrences: number
@@ -12,3 +24,4 @@ export interface IEntity {
 export declare const entities: IEntity[]
 export declare function getRootDomain(url: string): string
 export declare function getEntity(url: string): IEntity | undefined
+export declare function getProduct(url: string): IProduct | undefined

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@ export interface IFacade {
 export interface IProduct {
   name: string
   urlPatterns: string[]
-  facades: IFacade[]
+  facades?: IFacade[]
 }
 
 export interface IEntity {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,7 +15,7 @@ export interface IEntity {
   homepage?: string
   categories: string[]
   domains: string[]
-  products: IProduct[]
+  products?: IProduct[]
   averageExecutionTime: number
   totalExecutionTime: number
   totalOccurrences: number

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -141,7 +141,7 @@ describe('getProduct', () => {
         facades: [
           {
             name: "Lite YouTube",
-            repo: "https://github.com/paulirish/lite-youtube-embed#other-lite-embeds",
+            repo: "https://github.com/paulirish/lite-youtube-embed",
           },
         ],
         name: "YouTube Embedded Player",

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -136,20 +136,20 @@ describe('getEntity', () => {
 
 describe('getProduct', () => {
   it('works on basic url', () => {
-    expect(getProduct('https://www.youtube.com/embed/alGcULGtiv8')).toMatchInlineSnapshot(`
-      Object {
-        "facades": Array [
-          Object {
-            "name": "Lite YouTube",
-            "repo": "https://github.com/paulirish/lite-youtube-embed#other-lite-embeds",
+    expect(getProduct('https://www.youtube.com/embed/alGcULGtiv8')).toEqual(
+      {
+        facades: [
+          {
+            name: "Lite YouTube",
+            repo: "https://github.com/paulirish/lite-youtube-embed#other-lite-embeds",
           },
         ],
-        "name": "YouTube Embedded Player",
-        "urlPatterns": Array [
-          ".*\\\\.youtube\\\\.com/embed/.*",
+        name: "YouTube Embedded Player",
+        urlPatterns: [
+          ".*\\.youtube\\.com/embed/.*",
         ],
       }
-    `)
+    )
   })
 
   it('returns undefined with no products', () => {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const JSON5 = require('json5')
-const {entities, getRootDomain, getEntity} = require('./index.js')
+const {entities, getRootDomain, getEntity, getProduct} = require('./index.js')
 
 describe('getRootDomain', () => {
   it('works for IP addresses', () => {
@@ -131,6 +131,29 @@ describe('getEntity', () => {
   it('runs on data URIs', () => {
     const dataUri = 'data:image/gif;base64,R0lGODlhAQABAIAAAP8AADAAACwAAAAAAQABAAACAkQBADs='
     expect(getEntity(dataUri)).toEqual(undefined)
+  })
+})
+
+describe('getProduct', () => {
+  it('works on basic url', () => {
+    expect(getProduct('https://www.youtube.com/embed/alGcULGtiv8')).toMatchInlineSnapshot(`
+      Object {
+        "facades": Array [
+          Object {
+            "name": "Lite YouTube",
+            "repo": "https://github.com/paulirish/lite-youtube-embed#other-lite-embeds",
+          },
+        ],
+        "name": "YouTube Embedded Player",
+        "urlPatterns": Array [
+          ".*\\\\.youtube\\\\.com/embed/.*",
+        ],
+      }
+    `)
+  })
+
+  it('returns undefined with no products', () => {
+    expect(getProduct('https://unknown.typekit.net/fonts.css')).toEqual(undefined)
   })
 })
 


### PR DESCRIPTION
This PR adds an extra API function `getProduct` to get the product info of a URL if its entity has a matching product associated with it.  Products are matched by a list of regex patterns.

If a product has one or more facade alternatives, the name and repo link of the facade is in the object returned by `getProduct`.

Currently the only entity with a product section is YouTube for its embedded player:

```
  {
    name: 'YouTube',
    homepage: 'https://youtube.com',
    categories: ['video'],
    domains: ['*.ggpht.com', '*.youtube-nocookie.com', '*.youtube.com', '*.ytimg.com'],
    examples: [
      'www.youtube.com',
      's.ytimg.com',
      'yt3.ggpht.com',
      'img.youtube.com',
      'fcmatch.youtube.com',
    ],
    products: [
      {
        name: 'YouTube Embedded Player',
        urlPatterns: [
          '.*\\.youtube\\.com/embed/.*',
        ],
        facades: [
          {
            name: 'Lite YouTube',
            repo: 'https://github.com/paulirish/lite-youtube-embed#other-lite-embeds',
          },
        ],
      },
    ],
  },
```