### PR TITLE
Add Tiktok to known entities

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -9173,6 +9173,12 @@ module.exports = [
     domains: ['*.t-x.io', '*.tmcs.net'],
   },
   {
+    name: 'Tiktok',
+    homepage: 'https://www.tiktok.com/en/',
+    categories: ['social'],
+    domains: ['analytics.tiktok.com'],
+  },
+  {
     name: 'Tidio Live Chat',
     company: 'Tidio',
     homepage: 'https://www.tidiochat.com/en/',


### PR DESCRIPTION
Discovered from looking at a Speedcurve report, this was appearing as an Unknown Third Party.

I have suspicions that https://s0.ipstatp.com/ad/business/track-log.js may also be a TikTok domain but can't confirm them so I have just gone with the "known" domain for now.

![Screen Shot 2020-08-17 at 12 33 22 pm](https://user-images.githubusercontent.com/69268/90352181-e1b18080-e085-11ea-9c23-d8cc9aef3b3d.jpg)
