### PR TITLE
feat: add new LiveChat domains

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -629,9 +629,9 @@ module.exports = [
   },
   {
     name: 'LiveChat',
-    homepage: 'https://www.livechatinc.com/',
+    homepage: 'https://www.livechat.com/',
     categories: ['customer-success'],
-    domains: ['*.livechatinc.com'],
+    domains: ['*.livechatinc.com', '*.livechat.com', '*.livechat-static.com'],
     examples: ['cdn.livechatinc.com', 'secure.livechatinc.com'],
   },
   {


### PR DESCRIPTION
This PR adds two missing LiveChat domains:
* `livechat.com`, which we recently acquired and started using
* `livechat-static.com`, which we've been using for some time now