### PR TITLE
Cloudflare updates

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -351,7 +351,7 @@ module.exports = [
     name: 'Cloudflare CDN',
     homepage: 'https://cdnjs.com/',
     categories: ['cdn'],
-    domains: ['amp.cloudflare.com', 'cdnjs.cloudflare.com'],
+    domains: ['cdnjs.cloudflare.com', 'amp.cloudflare.com'],
   },
   {
     name: 'Cloudflare',


### PR DESCRIPTION
Cloudflare uses a.nel.cloudflare.com for Network Error Logging. Given Cloudflare's popularity this gets a lot of requests. I've chosen to add `*.nel.cloudflare.com` in case they every use anything other than `a` (e.g. `b`!) as seems quite specific anyway.

Additionally `https://static.cloudflareinsights.com` is used heavily for `https://static.cloudflareinsights.com/beacon.min.js`.

Finally, the `Cloudflare CDN` category incorrectly lists the domains in the wrong order:
```
domains: ['amp.cloudflare.com', 'cdnjs.cloudflare.com'],
```
Which means the CanonicalDomain is set to incorrectly in the Lighthouse BigQuery tables:
```sql
SELECT * FROM `lighthouse-infrastructure.third_party_web.2021_07_01` WHERE domain LIKE '%cloudflare.com'
```


----

HTTP Archive BigQuery showing heavy usage for queries in July crawl.

```sql
#standardSQL
# Top 100 third parties by number of websites

WITH requests AS (
  SELECT
    _TABLE_SUFFIX AS client,
    pageid AS page,
    url
  FROM
    `httparchive.summary_requests.2021_07_01_*`
),

totals AS (
  SELECT
    _TABLE_SUFFIX AS client,
    COUNT(0) AS total_pages
  FROM
    `httparchive.summary_pages.2021_07_01_*`
  GROUP BY _TABLE_SUFFIX
),

third_party AS (
  SELECT
    domain,
    canonicalDomain,
    category,
    COUNT(DISTINCT page) AS page_usage
  FROM
    `httparchive.almanac.third_parties` tp
  JOIN
    requests r
  ON NET.HOST(r.url) = NET.HOST(tp.domain)
  WHERE
    date = '2021-07-01' AND
    category = 'unknown'
  GROUP BY
    domain,
    canonicalDomain,
    category
  HAVING
    page_usage >= 50
)

SELECT
  client,
  url,
  domain,
  canonicalDomain,
  COUNT(DISTINCT page) AS pages,
  total_pages,
  COUNT(DISTINCT page) / total_pages AS pct_pages,
  DENSE_RANK() OVER (PARTITION BY client ORDER BY COUNT(DISTINCT page) DESC) AS sorted_order
FROM
  requests
LEFT JOIN
  third_party
ON
  NET.HOST(requests.url) = NET.HOST(third_party.domain)
JOIN
  totals
USING (client)
WHERE
  canonicalDomain IS NOT NULL AND
  (domain like '%.nel.cloudflare.com' OR domain like '%static.cloudflareinsights.com')
GROUP BY
  client,
  domain,
  url,
  total_pages,
  canonicalDomain
QUALIFY
  sorted_order <= 100
ORDER BY
  pct_pages DESC,
  client
```