### PR TITLE
Correct advertising category

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -11471,7 +11471,7 @@ module.exports = [
   {
     name: 'Click Guardian',
     homepage: 'https://www.clickguardian.co.uk/',
-    categories: ['advertising'],
+    categories: ['ad'],
     domains: ['*.clickguardian.app', '*.clickguardian.co.uk'],
     examples: ['v2.clickguardian.app', 'protection.clickguardian.co.uk'],
   },


### PR DESCRIPTION
Guardian is incorrectly using the non-existent `advertising` category instead of `ad`