### PR TITLE
Add Convertful

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -12169,4 +12169,11 @@ module.exports = [
     domains: ['*.wigzo.com','*.wigzopush.com'],
     examples: ['app.wigzo.com', 'tracker.wigzopush.com'],
   },
+  {
+    name: 'Convertful',
+    homepage: 'https://convertful.com/',
+    categories: ['marketing'],
+    domains: ['*.convertful.com'],
+    examples: ['app.convertful.com'],
+  },
 ]


### PR DESCRIPTION
Adds entity mapping for https://convertful.com/.

Convertful is an "All-In-One Tool to Turn Your Visitors Into Leads and Sales". Think popups, overlays and the like. Therefore I have categorised as 'marketing'.