### PR TITLE
Add *.swellrewards.com domain to the Yotpo entity.

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -10353,7 +10353,7 @@ module.exports = [
     name: 'Yotpo',
     homepage: 'https://www.yotpo.com/',
     categories: ['marketing'],
-    domains: ['*.yotpo.com'],
+    domains: ['*.yotpo.com', '*.swellrewards.com'],
   },
   {
     name: 'Yottaa',


### PR DESCRIPTION
Yotpo loyalty and rewards was previously known as Swell Rewards,
therefore this domain is still in use for some services.