### PR TITLE
Rationalise Loqate services and re-label to use current branding.

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -7127,10 +7127,10 @@ module.exports = [
     domains: ['*.adadyn.com'],
   },
   {
-    name: 'PCA Predict',
-    company: 'Postcode Anywhere',
+    name: 'Loqate',
+    company: 'Loqate',
     categories: ['other'],
-    domains: ['*.pcapredict.com'],
+    domains: ['*.pcapredict.com', '*.postcodeanywhere.co.uk'],
   },
   {
     name: 'PEER 1 Hosting',
@@ -7408,11 +7408,6 @@ module.exports = [
     name: 'Populis',
     categories: ['ad'],
     domains: ['*.populisengage.com'],
-  },
-  {
-    name: 'Postcode Anywhere (Holdings)',
-    categories: ['utility'],
-    domains: ['*.postcodeanywhere.co.uk'],
   },
   {
     name: 'Postimage.org',


### PR DESCRIPTION
Visiting the old pcapredict.com redirects to a landing page with the following message:

PCA Predict is now Loqate.
PCA Predict, GBG Matchcode 360, GBG Loqate, Addressy and Everything Location have unified as a single brand enabling us to deliver the best global data, technology and customer support on the market.