### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Add Dependabot config to keep GitHub Actions up-to-date (some of them in the `ci.yml` are not the latest versions).