### PR TITLE
Updated Google FundingChoices detection domain.

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -12135,7 +12135,7 @@ module.exports = [
     name: 'Google FundingChoices',
     homepage: 'https://fundingchoices.google.com/start/',
     category: 'consent-provider',
-    domains: ['fundingchoices.mgr.consensu.org', '*.fundingchoices.mgr.consensu.org'],
+    domains: ['fundingchoices.mgr.consensu.org', '*.fundingchoices.mgr.consensu.org', 'fundingchoicesmessages.google.com', '*.fundingchoicesmessages.google.com'],
   },
   {
     name: 'Gravito CMP',


### PR DESCRIPTION
Fixes Google FundingChoices CMP detection.

Example URLs: 

* https://dominik.net/
* https://www.phonearena.com/
