### PR TITLE
refactor: use query stream for automatic data update script

### DIFF
--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -155,7 +155,13 @@ async function main() {
       const thirdPartyWebTableWriterStream = new BigQuery()
         .dataset('third_party_web')
         .table(dateStringUnderscore)
-        .createWriteStream()
+        .createWriteStream({
+          schema: [
+            {name: 'domain', type: 'STRING'},
+            {name: 'canonicalDomain', type: 'STRING'},
+            {name: 'category', type: 'STRING'},
+          ],
+        })
       resultsStream
         // map observed domain to entity
         .pipe(EntityCanonicalDomainTransformer)

--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -84,6 +84,7 @@ const getQueryResultStream = async query => {
   const [job] = await new BigQuery().createQueryJob({
     query,
     location: 'US',
+    useQueryCache: false,
   })
   return job.getQueryResultsStream()
 }

--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -11,7 +11,7 @@ const HA_REQUESTS_TABLE_REGEX = /`httparchive\.requests\.\w+`/g
 const HA_LH_TABLE_REGEX = /`httparchive\.lighthouse\.\w+`/g
 const LH_3P_TABLE_REGEX = /`lighthouse-infrastructure\.third_party_web\.\w+`/g
 const DATE_UNDERSCORE_REGEX = /\d{4}_\d{2}_\d{2}/g
-const LH_REGEX = /lighthouse-infrastructure/g
+const LH_PROJECT_REGEX = /lighthouse-infrastructure/g
 
 const TABLE_REPLACEMENTS = process.env.USE_SAMPLE_DATA
   ? [

--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -125,7 +125,7 @@ async function main() {
         .dataset('third_party_web')
         .table(dateStringUnderscore)
       const start = Date.now()
-      const nbRows = 0
+      let nbRows = 0
       const schema = {
         schema: [
           {name: 'domain', type: 'STRING'},

--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -9,6 +9,7 @@ const HA_REQUESTS_TABLE_REGEX = /`httparchive\.requests\.\w+`/g
 const HA_LH_TABLE_REGEX = /`httparchive\.lighthouse\.\w+`/g
 const LH_3P_TABLE_REGEX = /`lighthouse-infrastructure\.third_party_web\.\w+`/g
 const DATE_UNDERSCORE_REGEX = /\d{4}_\d{2}_\d{2}/g
+const LH_REGEX = /lighthouse-infrastructure/g
 
 const TABLE_REPLACEMENTS = process.env.USE_SAMPLE_DATA
   ? [
@@ -20,6 +21,7 @@ const TABLE_REPLACEMENTS = process.env.USE_SAMPLE_DATA
       [process.env.OVERRIDE_HA_LH_TABLE, HA_LH_TABLE_REGEX],
       [process.env.OVERRIDE_HA_REQUESTS_TABLE, HA_REQUESTS_TABLE_REGEX],
       [process.env.OVERRIDE_LH_3P_TABLE, LH_3P_TABLE_REGEX],
+      [process.env.OVERRIDE_LH_PROJECT, LH_REGEX],
     ].filter(([override]) => override)
 
 function getQueryForTable(filename, dateUnderscore) {

--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -23,7 +23,7 @@ const TABLE_REPLACEMENTS = process.env.USE_SAMPLE_DATA
       [process.env.OVERRIDE_HA_LH_TABLE, HA_LH_TABLE_REGEX],
       [process.env.OVERRIDE_HA_REQUESTS_TABLE, HA_REQUESTS_TABLE_REGEX],
       [process.env.OVERRIDE_LH_3P_TABLE, LH_3P_TABLE_REGEX],
-      [process.env.OVERRIDE_LH_PROJECT, LH_REGEX],
+      [process.env.OVERRIDE_LH_PROJECT, LH_PROJECT_REGEX],
     ].filter(([override]) => override)
 
 function getQueryForTable(filename, dateUnderscore) {


### PR DESCRIPTION
Hello, 

While customizing SQL queries for future PRs, I got an error due to very large query results from big query. 

Issue occurs because of `JSON.stringify` can't be handle very large json results. It throws `RangeError: Invalid string length`. This issue makes script not scalable.  
Moving to stream fixes the issue as data is handled row by row (written to file and inserted in db). 

### Overwrite lighthouse-infrastructure project

This MR also adds a new environment variable `OVERRIDE_LH_PROJECT` to overwrite project containing `third-party-table` where script will create a new table (the one where we store mapping between observed domain and canonical one) then queried by `entity-per-page.sql`. It'll help in case script runner has no write access to hardcoded project in sql script (i.e `lighthouse-infrastructure`).