### PR TITLE
Update Osano references

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -12259,7 +12259,7 @@ module.exports = [
     name: 'Osano CMP',
     homepage: 'https://www.osano.com',
     category: 'consent-provider',
-    domains: ['osano.mgr.consensu.org', '*.osano.mgr.consensu.org'],
+    domains: ['cmp.osano.com', '*.api.osano.com'],
   },
   {
     name: 'Playwire CMP',


### PR DESCRIPTION
Hi - I'm a big fan of this project. I was looking for some data on Osano and noticed that, while there are entries in `2024-10-01-observed-domains.json` for some of their domains, there is nothing in `2024-10-01-entity-scripting.json`. I assume that the reason is because the domains listed in `entities.js` don't match the domains they are currently using. I'm thinking these changes will fix this issue, although I'm not sure how to test that myself