### PR TITLE
Use new HAR datsets to compute data

### DIFF
--- a/sql/all-observed-domains-query.sql
+++ b/sql/all-observed-domains-query.sql
@@ -25,7 +25,11 @@ FROM
                     page,
                     NET.HOST(url) AS domain
                 FROM
-                    `httparchive.requests.2022_01_01_mobile`
+                    `httparchive.crawl.requests`
+                WHERE
+                    date = "2022-01-01"
+                AND
+                    client = "mobile"
                 GROUP BY
                     page,
                     domain

--- a/sql/entity-per-page.sql
+++ b/sql/entity-per-page.sql
@@ -31,7 +31,7 @@ FROM
               page,
               lighthouse as report
             FROM
-              `httparchive.crawl.page`
+              `httparchive.crawl.pages`
             WHERE
               date = "2022-01-01"
             AND

--- a/sql/entity-per-page.sql
+++ b/sql/entity-per-page.sql
@@ -28,15 +28,19 @@ FROM
         FROM
           (
             SELECT
-              url AS page,
-              report
+              page,
+              lighthouse as report
             FROM
-              `httparchive.lighthouse.2022_01_01_mobile`
+              `httparchive.crawl.page`
+            WHERE
+              date = "2022-01-01"
+            AND
+              client = "mobile"
           ),
           UNNEST (
             JSON_QUERY_ARRAY(report, '$.audits.bootup-time.details.items')
           ) AS bootupTimeItems
-          INNER JOIN `lighthouse-infrastructure.third_party_web.2022_01_01` ON NET.HOST(JSON_VALUE(bootupTimeItems, "$.url")) = domain
+          INNER JOIN `lighthouse-infrastructure.third_party_web.2022-01-01` ON NET.HOST(JSON_VALUE(bootupTimeItems, "$.url")) = domain
       )
     WHERE
       canonicalDomain IS NOT NULL

--- a/sql/most-observed-domains-query.sql
+++ b/sql/most-observed-domains-query.sql
@@ -8,7 +8,11 @@ FROM
             NET.HOST(url) AS domain,
             COUNT(0) AS totalOccurrences
         FROM
-            `httparchive.requests.2022_01_01_mobile`
+            `httparchive.crawl.requests`
+        WHERE
+            date = "2022-01-01"
+        AND
+            client = "mobile"
         GROUP BY
             page,
             domain


### PR DESCRIPTION
HAR recently introduced new datasets for monthly internet archive. See [article](https://har.fyi/guides/migrating-to-crawl-dataset/) for more information. 

Unfortunately old datasets have been removed, breaking our data update script. 

This MR is here to fix script using new datasets.

PR #249 contains data for 2025/04 using new script. 