### PR TITLE
fix(entities): split Slideshare from LinkedIn

### DIFF
--- a/data/entities.js
+++ b/data/entities.js
@@ -1279,13 +1279,14 @@ module.exports = [
     name: 'LinkedIn',
     homepage: 'https://www.linkedin.com/',
     category: 'social',
-    domains: [
-      '*.bizographics.com',
-      'platform.linkedin.com',
-      '*.slideshare.com',
-      '*.slidesharecdn.com',
-      '*.oribi.io',
-    ],
+    domains: ['*.bizographics.com', 'platform.linkedin.com', '*.oribi.io'],
+  },
+  {
+    name: 'Slideshare',
+    homepage: 'https://www.slideshare.net/',
+    category: 'content',
+    domains: ['*.slideshare.com', '*.slideshare.net', '*.slidesharecdn.com'],
+    examples: ['public.slidesharecdn.com', 'image.slidesharecdn.com', 'www.slideshare.net'],
   },
   {
     name: 'LinkedIn Ads',


### PR DESCRIPTION
Slideshare was acquired from LinkedIn by Scribd in [September 2020](https://blog.scribd.com/home/scribd-completes-acquisition-of-slideshare). The `*.slideshare.com` and `*.slidesharecdn.com` domains were added to the LinkedIn entity in 2019 (commit 86a98e9) while LinkedIn still owned Slideshare, and have been carried forward since.

Moving them into a new `Slideshare` entity (category: `content`). The other LinkedIn-owned domains in the entity (`bizographics.com`, `oribi.io`) remain untouched.

Also adding `*.slideshare.net` (Slideshare's primary domain) which wasn't in the entry before.

Noticed this while auditing third-party impact on slideshare.net itself ... our own CDN traffic was reporting as third-party LinkedIn in Lighthouse / Chrome DevTools.